### PR TITLE
Modifying the insert function for VerifySet/Map/List

### DIFF
--- a/src/classes/ajpf/util/VerifyList.java
+++ b/src/classes/ajpf/util/VerifyList.java
@@ -179,20 +179,33 @@ public class VerifyList<K extends Comparable<? super K>> implements List<K> {
 	 * @return
 	 */
 	private K insert(K t) {
+		//fatma - modifying to get remove addition of elements in loop
+		int index_to_add_at = -1;
+		K element_to_return = null;
 		for (int i = 0; i < sortedlist.size(); i++) {
 			K t1 = sortedlist.get(i);
 			int comparison = t.compareTo(t1);
 			if (comparison < 0) {
-				sortedlist.add(i, t);
-				return null;
+				index_to_add_at = i;
+				break;
+//				sortedlist.add(i, t);
+//				return null;
 			} else if (comparison == 0) {
-				sortedlist.add(i, t);
-				return t1;
+				index_to_add_at = i;
+				element_to_return = t1;
+				break;
+//				sortedlist.add(i, t);
+//				return t1;
 			}
 		}
-		
-		sortedlist.add(t);
-		return null;
+		if(index_to_add_at!=-1)
+		{
+			sortedlist.add(index_to_add_at,t);
+		}
+		else {
+			sortedlist.add(t);
+		}
+		return element_to_return;
 	}
 	
 	/*

--- a/src/classes/ajpf/util/VerifyMap.java
+++ b/src/classes/ajpf/util/VerifyMap.java
@@ -201,25 +201,46 @@ public class VerifyMap<K extends Comparable<? super K>, V> implements Map<K, V> 
 	 * @return
 	 */
 	private V insert(Tuple<K, V> t) {
+		//fatma - changing this so we do dont modify the array (add things) in the loop
+		V element_to_return = null;
+		int index_to_add_at = -1;
 		for (int i = 0; i < tuplearray.size(); i++) {
 			Tuple<K, V> t1 = tuplearray.get(i);
 			int comparison = t.getKey().compareTo(t1.getKey());
 			if (comparison < 0) {
-				tuplearray.add(i, t);
-				tuplearray.trimToSize();
-				return null;
+				index_to_add_at = i;
+				break;
+//				tuplearray.add(i, t);
+//				tuplearray.trimToSize();
+//				return null;
 			} else if (comparison == 0) {
-				V returnvalue = t1.getValue();
-				tuplearray.remove(i);
-				tuplearray.trimToSize();
-				tuplearray.add(i, t);
-				return returnvalue;
+				element_to_return = t1.getValue();
+				index_to_add_at = i;
+				break;
+//				tuplearray.remove(i);
+//				tuplearray.trimToSize();
+//				tuplearray.add(i, t);
+//				return returnvalue;
 			}
 		}
-		
-		tuplearray.add(t);
-		tuplearray.trimToSize();
-		return null;
+		if(index_to_add_at != -1)
+		{
+			if(element_to_return!=null)
+			{
+				tuplearray.remove(index_to_add_at);
+				tuplearray.trimToSize();
+				tuplearray.add(index_to_add_at,t);
+			}
+			else{
+				tuplearray.add(index_to_add_at,t);
+				tuplearray.trimToSize();
+			}
+		}
+		else {
+			tuplearray.add(t);
+			tuplearray.trimToSize();
+		}
+		return element_to_return;
 	}
 	
 	/*

--- a/src/classes/ajpf/util/VerifySet.java
+++ b/src/classes/ajpf/util/VerifySet.java
@@ -135,20 +135,33 @@ public class VerifySet<K extends Comparable<? super K>> implements SortedSet<K> 
 	 * @return
 	 */
 	private K insert(K t) {
+		//fatma changing this to move the addition
+		// outside - hopefully avoid concurrent comodification errors
+		int index_to_add_at = -1;
+		K element_to_return = null;
+
 		for (int i = 0; i < sortedlist.size(); i++) {
 			K t1 = sortedlist.get(i);
 			int comparison = t.compareTo(t1);
 			if (comparison < 0) {
-				sortedlist.add(i, t);
-				return null;
+				index_to_add_at = i;
+				break;
+//				sortedlist.add(i, t);
+//				return null;
 			} else if (comparison == 0) {
-				sortedlist.add(i, t);
-				return t1;
+				index_to_add_at = i;
+				element_to_return = t1;
+				break;
+//				sortedlist.add(i, t);
+//				return t1;
 			}
 		}
-		
+		if(index_to_add_at != -1)
+		{
+			sortedlist.add(index_to_add_at,t);
+		}else
 		sortedlist.add(t);
-		return null;
+		return element_to_return;
 	}
 	
 	/*


### PR DESCRIPTION
Hopefully removing the concurrent commodification error. Percepts are of type verify set. The insert function was iterating over a list and adding elements during iteration. Modified the insert function for all three Verify* (Set,List,Map). Hope this fixes things and doesn't change functionality. 